### PR TITLE
chore: fix ci pipeline and enable black/ruff linting

### DIFF
--- a/.github/workflows/starter-workflow.yaml
+++ b/.github/workflows/starter-workflow.yaml
@@ -4,14 +4,15 @@ on: [push]
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -19,15 +20,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install https://huggingface.co/royashcenazi/en_parsigs/resolve/main/en_parsigs-any-py3-none-any.whl
-          pip install ruff pytest
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-     # - name: Lint with ruff
-     #   run: |
-          # stop the build if there are Python syntax errors or undefined names
-     #     ruff --format=github --select=E9,F63,F7,F82 --target-version=py37 .
-          # default set of ruff rules with GitHub Annotations
-     #     ruff --format=github --target-version=py37 .
-      - name: Test with pytest
-        run: |
-          pytest
+          pip install tox tox-gh-actions
+      - name: Run tox
+        run: tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,14 +14,22 @@ readme = "README.md"
 dependencies = [
     "spacy>=3.0,<4.0",
     "word2number",
-    "inflect"
-#    "en-parsigs @ https://huggingface.co/royashcenazi/en_parsigs/resolve/main/en_parsigs-any-py3-none-any.whl",
+    "inflect",
+    "en-parsigs @ https://huggingface.co/royashcenazi/en_parsigs/resolve/main/en_parsigs-any-py3-none-any.whl",
     "pyspellchecker<= 0.5.5",
 ]
 
-[tool.hatch.metadata]
-#allow-direct-references = true
+[project.optional-dependencies]
+dev = [
+    "hypothesis",
+    "pytest",
+    "pytest-cov",
+    "ruff",
+    "tox",
+]
 
+[tool.hatch.metadata]
+allow-direct-references = true
 requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -32,3 +40,31 @@ classifiers = [
 [project.urls]
 "Homepage" = "https://github.com/royashcenazi/parsigs"
 "Bug Tracker" = "https://github.com/royashcenazi/parsigs/issues"
+
+[tool.ruff]
+src = ["src", "tests"]
+target-version = "py37"
+select = [
+    "A",    #  builtins
+    "ARG",  #  unsued arguments
+    "B",    #  bugbear
+    "C4",   #  comprehensions
+    "C90",  #  mccabe
+    "COM",  #  commas
+    "E",    #  pycodestyle
+    "F",    #  pyflakes
+    "I",    #  isort
+    "N",    #  pep8-naming
+    "PT",   #  pytest style
+    "RUF",  #  ruff
+    "SIM",  #  simplify
+    "TID",  #  tidy imports
+    "UP",   #  pyupgrade
+    "W",    #  warnings
+]
+
+[tool.ruff.mccabe]
+max-complexity = 8
+
+[tool.ruff.isort]
+force-single-line = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-spacy>=3.0,<4.0
-word2number
-pyspellchecker<= 0.5.5
-inflect

--- a/tests/test_inflect.py
+++ b/tests/test_inflect.py
@@ -1,5 +1,7 @@
 import unittest
 import inflect
+
+
 class TestInflect(unittest.TestCase):
     def test_inflect(self):
         self.assertEqual(inflect.engine().singular_noun("tablets"), "tablet")

--- a/tests/test_parsig_api.py
+++ b/tests/test_parsig_api.py
@@ -1,6 +1,7 @@
 import unittest
 
-from parsigs.parse_sig_api import StructuredSig, SigParser
+from parsigs.parse_sig_api import SigParser
+from parsigs.parse_sig_api import StructuredSig
 
 
 class TestParseSigApi(unittest.TestCase):
@@ -8,121 +9,320 @@ class TestParseSigApi(unittest.TestCase):
 
     def test_parse_sig_basic(self):
         sig = "Take 1 tablet 3 times a day for 2 weeks"
-        expected = StructuredSig(drug=None, form="tablet", strength=None, frequencyType="Day", interval=3, singleDosageAmount=1.0, periodType='Week', periodAmount=2, takeAsNeeded=False)
+        expected = StructuredSig(
+            drug=None,
+            form="tablet",
+            strength=None,
+            frequency_type="Day",
+            interval=3,
+            single_dosage_amount=1.0,
+            period_type="Week",
+            period_amount=2,
+            take_as_needed=False,
+        )
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_sig_strength(self):
         sig = "Take 1 tablet of ibuprofen 200mg 3 times every day for 10 weeks"
-        expected = StructuredSig(drug="ibuprofen", form="tablet", strength="200mg", frequencyType="Day", interval=3, singleDosageAmount=1.0, periodType="Week", periodAmount=10, takeAsNeeded=False)
+        expected = StructuredSig(
+            drug="ibuprofen",
+            form="tablet",
+            strength="200mg",
+            frequency_type="Day",
+            interval=3,
+            single_dosage_amount=1.0,
+            period_type="Week",
+            period_amount=10,
+            take_as_needed=False,
+        )
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_sig_period(self):
         sig = "Take 2 tabs of amoxicillin 500mg every 12 days for 10 days"
-        expected = StructuredSig(drug="amoxicillin", form="tab", strength="500mg", frequencyType="Day", interval=12, singleDosageAmount=2.0, periodType="Day", periodAmount=10, takeAsNeeded=False)
+        expected = StructuredSig(
+            drug="amoxicillin",
+            form="tab",
+            strength="500mg",
+            frequency_type="Day",
+            interval=12,
+            single_dosage_amount=2.0,
+            period_type="Day",
+            period_amount=10,
+            take_as_needed=False,
+        )
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_no_drug(self):
         sig = "Take 1 pill 3 times a day"
-        expected = StructuredSig(drug=None, form='pill', strength=None, frequencyType="Day", interval=3, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        expected = StructuredSig(
+            drug=None,
+            form="pill",
+            strength=None,
+            frequency_type="Day",
+            interval=3,
+            single_dosage_amount=1.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=False,
+        )
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_sig_text_and_regular_numbers(self):
         sig = "Take two tablets of ibuprofen 3 times every week"
-        expected = StructuredSig(drug='ibuprofen', form='tablet', strength=None, frequencyType="Week", interval=3, singleDosageAmount=2.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        expected = StructuredSig(
+            drug="ibuprofen",
+            form="tablet",
+            strength=None,
+            frequency_type="Week",
+            interval=3,
+            single_dosage_amount=2.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=False,
+        )
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_unprocessed_sig(self):
         sig = "INHALE 2 puffs EVERY DAY"
-        expected = StructuredSig(drug=None, form='puff', strength=None, frequencyType="Day", interval=1, singleDosageAmount=2.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        expected = StructuredSig(
+            drug=None,
+            form="puff",
+            strength=None,
+            frequency_type="Day",
+            interval=1,
+            single_dosage_amount=2.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=False,
+        )
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_as_needed(self):
         sig = "TAKE 1 TABLET BY MOUTH EVERY 6 HOURS AS NEEDED FOR PAIN"
-        expected = StructuredSig(drug=None, form='tablet', strength=None, frequencyType="Hour", interval=6, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=True)
+        expected = StructuredSig(
+            drug=None,
+            form="tablet",
+            strength=None,
+            frequency_type="Hour",
+            interval=6,
+            single_dosage_amount=1.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=True,
+        )
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_sig_short_form(self):
         sig = "Take 1 tab of Benadryl 3 times a day"
-        expected = StructuredSig(drug='benadryl', form='tablet', strength=None, frequencyType="Day", interval=3, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        expected = StructuredSig(
+            drug="benadryl",
+            form="tablet",
+            strength=None,
+            frequency_type="Day",
+            interval=3,
+            single_dosage_amount=1.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=False,
+        )
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_sig_no_form(self):
         sig = "Take 1 codeine 3 times a day"
-        expected = StructuredSig(drug='codeine', form=None, strength=None, frequencyType="Day", interval=3, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        expected = StructuredSig(
+            drug="codeine",
+            form=None,
+            strength=None,
+            frequency_type="Day",
+            interval=3,
+            single_dosage_amount=1.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=False,
+        )
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_sig_every_other_time_unit(self):
         sig = "TAKE 1 TABLET BY MOUTH EVERY OTHER DAY"
-        expected = StructuredSig(drug=None, form='tablet', strength=None, frequencyType="Day", interval=2, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        expected = StructuredSig(
+            drug=None,
+            form="tablet",
+            strength=None,
+            frequency_type="Day",
+            interval=2,
+            single_dosage_amount=1.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=False,
+        )
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_sig_latin(self):
         sig = "1 TAB of BENADRYL BID"
-        expected = StructuredSig(drug="benadryl", form='tablet', strength=None, frequencyType="Day", interval=2, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        expected = StructuredSig(
+            drug="benadryl",
+            form="tablet",
+            strength=None,
+            frequency_type="Day",
+            interval=2,
+            single_dosage_amount=1.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=False,
+        )
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_sig_capsules(self):
         sig = "Take 2 capsules of amoxicillin 500mg"
-        expected = StructuredSig(drug="amoxicillin", form="capsule", strength="500mg", frequencyType=None, interval=None, singleDosageAmount=2.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        expected = StructuredSig(
+            drug="amoxicillin",
+            form="capsule",
+            strength="500mg",
+            frequency_type=None,
+            interval=None,
+            single_dosage_amount=2.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=False,
+        )
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_multiple_instructions(self):
         sig = "take 1 tablet of atorvastatin every day and then 2 tablets every week"
-        first_expected = StructuredSig(drug="atorvastatin", form="tablet", strength=None, frequencyType="Day",
-                                       interval=1, singleDosageAmount=1.0, periodType=None, periodAmount=None,
-                                       takeAsNeeded=False)
-        second_expected = StructuredSig(drug="atorvastatin", form="tablet", strength=None, frequencyType="Week",
-                                        interval=1, singleDosageAmount=2.0, periodType=None, periodAmount=None,
-                                        takeAsNeeded=False)
+        first_expected = StructuredSig(
+            drug="atorvastatin",
+            form="tablet",
+            strength=None,
+            frequency_type="Day",
+            interval=1,
+            single_dosage_amount=1.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=False,
+        )
+        second_expected = StructuredSig(
+            drug="atorvastatin",
+            form="tablet",
+            strength=None,
+            frequency_type="Week",
+            interval=1,
+            single_dosage_amount=2.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=False,
+        )
         result = self.sig_parser.parse(sig)
         expected = [first_expected, second_expected]
         self.assertEqual(result, expected)
 
     def test_parse_multiple_instructions2(self):
         sig = "take two tablets of benadryl every two days and then 1 tablet as needed"
-        first_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType="Day", interval=2,
-                                       singleDosageAmount=2.0, periodType=None, periodAmount=None, takeAsNeeded=False)
-        second_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType=None, interval=1,
-                                        singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=True)
+        first_expected = StructuredSig(
+            drug="benadryl",
+            form="tablet",
+            strength=None,
+            frequency_type="Day",
+            interval=2,
+            single_dosage_amount=2.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=False,
+        )
+        second_expected = StructuredSig(
+            drug="benadryl",
+            form="tablet",
+            strength=None,
+            frequency_type=None,
+            interval=1,
+            single_dosage_amount=1.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=True,
+        )
         result = self.sig_parser.parse(sig)
         expected = [first_expected, second_expected]
         self.assertEqual(result, expected)
 
     def test_parse_multiple_instructions3(self):
         sig = "take two tablets of benadryl every two days and then 1 tablet every week for 1 month and than 1 tablet every month"
-        first_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType="Day", interval=2,
-                                       singleDosageAmount=2.0, periodType=None, periodAmount=None, takeAsNeeded=False)
-        second_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType='Week', interval=1,
-                                        singleDosageAmount=1.0, periodType='Month', periodAmount=1, takeAsNeeded=False)
-        third_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType='Month', interval=1,
-                                       singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        first_expected = StructuredSig(
+            drug="benadryl",
+            form="tablet",
+            strength=None,
+            frequency_type="Day",
+            interval=2,
+            single_dosage_amount=2.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=False,
+        )
+        second_expected = StructuredSig(
+            drug="benadryl",
+            form="tablet",
+            strength=None,
+            frequency_type="Week",
+            interval=1,
+            single_dosage_amount=1.0,
+            period_type="Month",
+            period_amount=1,
+            take_as_needed=False,
+        )
+        third_expected = StructuredSig(
+            drug="benadryl",
+            form="tablet",
+            strength=None,
+            frequency_type="Month",
+            interval=1,
+            single_dosage_amount=1.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=False,
+        )
         result = self.sig_parser.parse(sig)
         expected = [first_expected, second_expected, third_expected]
         self.assertEqual(result, expected)
 
     def test_autocorrect_and__pre_process1(self):
         sig = "Tkae 1 tabet 3 tiems a day for 2 wekes"
-        expected = StructuredSig(drug=None, form="tablet", strength=None, frequencyType="Day", interval=3,
-                                 singleDosageAmount=1.0, periodType='Week', periodAmount=2, takeAsNeeded=False)
+        expected = StructuredSig(
+            drug=None,
+            form="tablet",
+            strength=None,
+            frequency_type="Day",
+            interval=3,
+            single_dosage_amount=1.0,
+            period_type="Week",
+            period_amount=2,
+            take_as_needed=False,
+        )
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_autocorrect_and__pre_process2(self):
         sig = "Tkae 1 talbet of ibuprofen 200mg 3 tiems every day for 10 wekes"
-        expected = StructuredSig(drug="ibuprofen", form="tablet", strength="200mg", frequencyType="Day", interval=3,
-                                 singleDosageAmount=1.0, periodType="Week", periodAmount=10, takeAsNeeded=False)
+        expected = StructuredSig(
+            drug="ibuprofen",
+            form="tablet",
+            strength="200mg",
+            frequency_type="Day",
+            interval=3,
+            single_dosage_amount=1.0,
+            period_type="Week",
+            period_amount=10,
+            take_as_needed=False,
+        )
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
@@ -135,15 +335,33 @@ class TestParseSigApi(unittest.TestCase):
     #
     def test_autocorrect_and__pre_process4(self):
         sig = "Atke 1 tab of Benadryl 3 tmies a day"
-        expected = StructuredSig(drug='benadryl', form='tablet', strength=None, frequencyType="Day", interval=3,
-                                 singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        expected = StructuredSig(
+            drug="benadryl",
+            form="tablet",
+            strength=None,
+            frequency_type="Day",
+            interval=3,
+            single_dosage_amount=1.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=False,
+        )
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_autocorrect_and_pre_process5(self):
         sig = "takr 1 tablet of Benadryl 3 times a dya"
-        expected = StructuredSig(drug='benadryl', form='tablet', strength=None, frequencyType="Day", interval=3,
-                                 singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        expected = StructuredSig(
+            drug="benadryl",
+            form="tablet",
+            strength=None,
+            frequency_type="Day",
+            interval=3,
+            single_dosage_amount=1.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=False,
+        )
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
@@ -157,12 +375,39 @@ class TestParseSigApi(unittest.TestCase):
 
     def test_autocorrect_and_pre_process7(self):
         sig = "tkae two talbets of benadryl every two days and then 1 talbet every week for 1 month and than 1 talbet every month"
-        first_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType="Day", interval=2,
-                                       singleDosageAmount=2.0, periodType=None, periodAmount=None, takeAsNeeded=False)
-        second_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType='Week', interval=1,
-                                        singleDosageAmount=1.0, periodType='Month', periodAmount=1, takeAsNeeded=False)
-        third_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType='Month', interval=1,
-                                       singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        first_expected = StructuredSig(
+            drug="benadryl",
+            form="tablet",
+            strength=None,
+            frequency_type="Day",
+            interval=2,
+            single_dosage_amount=2.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=False,
+        )
+        second_expected = StructuredSig(
+            drug="benadryl",
+            form="tablet",
+            strength=None,
+            frequency_type="Week",
+            interval=1,
+            single_dosage_amount=1.0,
+            period_type="Month",
+            period_amount=1,
+            take_as_needed=False,
+        )
+        third_expected = StructuredSig(
+            drug="benadryl",
+            form="tablet",
+            strength=None,
+            frequency_type="Month",
+            interval=1,
+            single_dosage_amount=1.0,
+            period_type=None,
+            period_amount=None,
+            take_as_needed=False,
+        )
         result = self.sig_parser.parse(sig)
         expected = [first_expected, second_expected, third_expected]
         self.assertEqual(result, expected)

--- a/tests/test_propery_parsig_api.py
+++ b/tests/test_propery_parsig_api.py
@@ -1,8 +1,11 @@
 import random
-
-from hypothesis import given, settings, strategies as st
 import unittest
-from parsigs.parse_sig_api import SigParser, StructuredSig
+
+from hypothesis import given
+from hypothesis import settings
+from hypothesis import strategies as st
+from parsigs.parse_sig_api import SigParser
+from parsigs.parse_sig_api import StructuredSig
 
 
 class TestParseSigApi(unittest.TestCase):
@@ -12,7 +15,19 @@ class TestParseSigApi(unittest.TestCase):
     @settings(max_examples=30)
     def test_parse_sig_strength(self, strength):
         sig = f"Take 1 tablet of ibuprofen {strength}mg 3 times every day for 10 weeks"
-        expected = StructuredSig(drug="ibuprofen", form="tablet", strength=f"{strength}mg", frequencyType="Day", interval=3, singleDosageAmount=1.0, periodType="Week", periodAmount=10, takeAsNeeded=False)
+        expected = [
+            StructuredSig(
+                drug="ibuprofen",
+                form="tablet",
+                strength=f"{strength}mg",
+                frequency_type="Day",
+                interval=3,
+                single_dosage_amount=1.0,
+                period_type="Week",
+                period_amount=10,
+                take_as_needed=False,
+            ),
+        ]
         result = self.parser.parse(sig)
         self.assertEqual(result, expected)
 
@@ -20,14 +35,11 @@ class TestParseSigApi(unittest.TestCase):
         count_tabs=st.integers(min_value=1, max_value=5),
         count_mg=st.integers(min_value=300, max_value=500),
         count_every_days=st.integers(min_value=3, max_value=10),
-        count_days=st.integers(min_value=4, max_value=10)
+        count_days=st.integers(min_value=4, max_value=10),
     )
-    def test_parse_sig_period(self,
-            count_tabs: int,
-            count_mg: int,
-            count_every_days: int,
-            count_days: int
-    ) -> bool:
+    def test_parse_sig_period(
+        self, count_tabs: int, count_mg: int, count_every_days: int, count_days: int,
+    ):
         """
         Test parsing prescription instructions with period values.
 
@@ -56,17 +68,19 @@ class TestParseSigApi(unittest.TestCase):
         sig = f"Take {count_tabs} tablets of amoxicillin {count_mg}mg every {count_every_days} days for {count_days} {period_for_string}"
 
         # Expected StructuredSig using random values
-        expected = StructuredSig(
-            drug="amoxicillin",
-            form="tablets",
-            strength=f"{count_mg}mg",
-            frequencyType="Day",
-            interval=count_every_days,
-            singleDosageAmount=float(count_tabs),
-            periodType=period_for_obj,
-            periodAmount=count_days,
-            takeAsNeeded=False
-        )
+        expected = [
+            StructuredSig(
+                drug="amoxicillin",
+                form="tablet",
+                strength=f"{count_mg}mg",
+                frequency_type="Day",
+                interval=count_every_days,
+                single_dosage_amount=float(count_tabs),
+                period_type=period_for_obj,
+                period_amount=count_days,
+                take_as_needed=False,
+            ),
+        ]
 
         # Parse prescription string
         result = self.parser.parse(sig)
@@ -75,7 +89,5 @@ class TestParseSigApi(unittest.TestCase):
         self.assertEqual(result, expected)
 
 
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,33 @@
+[tox]
+isolated_build = True
+envlist =
+    py37
+    py38
+    py39
+    py310
+    py311
+    lint
+
+[testenv]
+passenv = USERNAME
+deps =
+    pytest
+    hypothesis
+commands =
+    pytest
+
+[testenv:lint]
+deps =
+    black
+    ruff
+commands =
+    black --check parsigs/
+    ruff check parsigs/
+
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311, lint


### PR DESCRIPTION
This PR fixes the CI pipeline and adds the following tools for parity between the pipeline and local env:
- tox
- black
- ruff
The linting rules can be found in `pyproject.toml` while the testing rules can be found in `tox.ini`

It is now also easier to install the package, its dependencies, and any dev requirement locally using `pip install -e ".[dev]"` so there is no need for a redundant `requirements.txt` file