### PR TITLE
Diffrentiating time and interval fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,21 +47,22 @@ sig_parser = SigParser()
 sig = "Take 1 tablet of ibuprofen 200mg 3 times every day for 3 weeks"
 parsed_sig = sig_parser.parse(sig)
 
-expected = StructuredSig(drug="ibuprofen", form="tablet", strength="200mg", frequencyType="Day", interval=3, singleDosageAmount=1.0, periodType='Week', periodAmount=3, takeAsNeeded=False)
+expected = StructuredSig(drug="ibuprofen", form="tablet", strength="200mg", frequencyType="Day", times=3, interval=1, singleDosageAmount=1.0, periodType='Week', periodAmount=3, takeAsNeeded=False)
 
-sig2 = "Take 2 tablets 3 times every month"
+sig2 = "Take 2 tablets every 2 weeks"
 parsed_sig = sig_parser.parse(sig2)
 
-expected = StructuredSig(drug=None, form='tablets', strength=None, frequencyType='Month', interval=3, singleDosageAmount=2.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+expected = StructuredSig(drug=None, form='tablets', strength=None, frequencyType='Week', interval=2, singleDosageAmount=2.0, times=None, periodType=None, periodAmount=None, takeAsNeeded=False)
 ```
 
 The `StructuredSig` object has the following attributes:
 - `drug`: the name of the drug
 - `form`: the form of the medication (e.g. tablet, solution, pill)
 - `strength`: the strength of the medication (e.g. 200mg, 500mg)
-- `frequencyType`: the time-unit of the frequency (e.g. Day, Week, Month)
-- `interval`: the number of times per frequency time-unit
 - `singleDosageAmount`: the amount of the medication to take at each interval
+- `frequencyType`: the time-unit of the frequency (e.g. Day, Week, Month)
+- `times`: how many times a single dosage amount should be taken in a time unit
+- `interval`: if the instruction is every X days/hours/weeks/months - the X value is the interval
 - `periodType`: the unit-type of the period which indicates for how long medication should be taken (e.g. Day, Week, Month)
 - `periodAmount`: the number of units per `periodType`
 - `takeAsNeeded`: a flag indicating if the instructed dosage should be taken only when the patient needs it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "parsigs"
-version = "0.0.6_beta"
+version = "1.0.1_beta"
 authors = [
     { name = "Roy Ashcenazi", email = "royashcenazi@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "parsigs"
-version = "1.0.1_beta"
+version = "1.1.0_beta"
 authors = [
     { name = "Roy Ashcenazi", email = "royashcenazi@gmail.com" },
 ]

--- a/tests/test_parsig_api.py
+++ b/tests/test_parsig_api.py
@@ -8,90 +8,106 @@ class TestParseSigApi(unittest.TestCase):
 
     def test_parse_sig_basic(self):
         sig = "Take 1 tablet 3 times a day for 2 weeks"
-        expected = StructuredSig(drug=None, form="tablet", strength=None, frequencyType="Day", interval=3, singleDosageAmount=1.0, periodType='Week', periodAmount=2, takeAsNeeded=False)
+        expected = StructuredSig(drug=None, form="tablet", strength=None, frequencyType="Day", interval=1, times=3, singleDosageAmount=1.0, periodType='Week', periodAmount=2, takeAsNeeded=False)
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
-    def test_parse_sig_strength(self):
-        sig = "Take 1 tablet of ibuprofen 200mg 3 times every day for 10 weeks"
-        expected = StructuredSig(drug="ibuprofen", form="tablet", strength="200mg", frequencyType="Day", interval=3, singleDosageAmount=1.0, periodType="Week", periodAmount=10, takeAsNeeded=False)
-        result = self.sig_parser.parse(sig)[0]
-        self.assertEqual(result, expected)
 
+
+# When there is a mix of times and every, the model does not tag well the frequency
+# Not sure if this is a valid use case (instead of times probably it would be "take 3 tablets every 2 days" but in order
+# To solve, designated training examples should be introduced to the model
+    # def test_parse_sig_interval_and_times(self):
+    #     sig = "Take 1 tablet of ibuprofen 200mg 3 times every 2 weeks for 10 weeks"
+    #     expected = StructuredSig(drug="ibuprofen", form="tablet", strength="200mg", frequencyType="Day", times=3, interval=2, singleDosageAmount=1.0, periodType="Week", periodAmount=10, takeAsNeeded=False)
+    #     result = self.sig_parser.parse(sig)[0]
+    #     self.assertEqual(result, expected)
+
+    # def test_parse_sig_strength(self):
+    #     sig = "Take 1 tablet of ibuprofen 200mg 3 times every two days for 10 weeks"
+    #     expected = StructuredSig(drug="ibuprofen", form="tablet", strength="200mg", frequencyType="Day", interval=3, singleDosageAmount=1.0, periodType="Week", periodAmount=10, takeAsNeeded=False)
+    #     result = self.sig_parser.parse(sig)[0]
+    #     self.assertEqual(result, expected)
     def test_parse_sig_period(self):
         sig = "Take 2 tabs of amoxicillin 500mg every 12 days for 10 days"
-        expected = StructuredSig(drug="amoxicillin", form="tab", strength="500mg", frequencyType="Day", interval=12, singleDosageAmount=2.0, periodType="Day", periodAmount=10, takeAsNeeded=False)
+        expected = StructuredSig(drug="amoxicillin", form="tab", strength="500mg", times=None, frequencyType="Day", interval=12, singleDosageAmount=2.0, periodType="Day", periodAmount=10, takeAsNeeded=False)
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_sig_period_year(self):
         sig = "Take 2 tabs of amoxicillin 500mg every 12 days for 2 years"
         expected = StructuredSig(drug="amoxicillin", form="tab", strength="500mg", frequencyType="Day", interval=12, 
-                                 singleDosageAmount=2.0, periodType="Year", periodAmount=2, takeAsNeeded=False)
+                                 singleDosageAmount=2.0, periodType="Year", periodAmount=2, takeAsNeeded=False, times=None)
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_no_drug(self):
         sig = "Take 1 pill 3 times a day"
-        expected = StructuredSig(drug=None, form='pill', strength=None, frequencyType="Day", interval=3, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        expected = StructuredSig(drug=None, form='pill', strength=None, frequencyType="Day", interval=1, times=3, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_sig_text_and_regular_numbers(self):
         sig = "Take two tablets of ibuprofen 3 times every week"
-        expected = StructuredSig(drug='ibuprofen', form='tablet', strength=None, frequencyType="Week", interval=3, singleDosageAmount=2.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        expected = StructuredSig(drug='ibuprofen', form='tablet', strength=None, frequencyType="Week", interval=1, times=3, singleDosageAmount=2.0, periodType=None, periodAmount=None, takeAsNeeded=False)
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_unprocessed_sig(self):
         sig = "INHALE 2 puffs EVERY DAY"
-        expected = StructuredSig(drug=None, form='puff', strength=None, frequencyType="Day", interval=1, singleDosageAmount=2.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        expected = StructuredSig(drug=None, form='puff', strength=None, frequencyType="Day", interval=1, times=None, singleDosageAmount=2.0, periodType=None, periodAmount=None, takeAsNeeded=False)
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_as_needed(self):
         sig = "TAKE 1 TABLET BY MOUTH EVERY 6 HOURS AS NEEDED FOR PAIN"
-        expected = StructuredSig(drug=None, form='tablet', strength=None, frequencyType="Hour", interval=6, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=True)
+        expected = StructuredSig(drug=None, form='tablet', strength=None, frequencyType="Hour", interval=6, times=None, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=True)
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_sig_short_form(self):
         sig = "Take 1 tab of Benadryl 3 times a day"
-        expected = StructuredSig(drug='benadryl', form='tablet', strength=None, frequencyType="Day", interval=3, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        expected = StructuredSig(drug='benadryl', form='tablet', strength=None, frequencyType="Day", interval=1, times=3, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_sig_no_form(self):
         sig = "Take 1 codeine 3 times a day"
-        expected = StructuredSig(drug='codeine', form=None, strength=None, frequencyType="Day", interval=3, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        expected = StructuredSig(drug='codeine', form=None, strength=None, frequencyType="Day", times=3, interval=1, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_sig_every_other_time_unit(self):
         sig = "TAKE 1 TABLET BY MOUTH EVERY OTHER DAY"
-        expected = StructuredSig(drug=None, form='tablet', strength=None, frequencyType="Day", interval=2, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        expected = StructuredSig(drug=None, form='tablet', strength=None, frequencyType="Day", interval=2, times=None, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_sig_latin(self):
         sig = "1 TAB of BENADRYL BID"
-        expected = StructuredSig(drug="benadryl", form='tablet', strength=None, frequencyType="Day", interval=2, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        expected = StructuredSig(drug="benadryl", form='tablet', strength=None, interval=1, frequencyType="Day", times=2, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        result = self.sig_parser.parse(sig)[0]
+        self.assertEqual(result, expected)
+
+    def test_parse_sig_latin2(self):
+        sig = "1 TAB of BENADRYL qd times"
+        expected = StructuredSig(drug="benadryl", form='tablet', strength=None, interval=1, frequencyType="Day", times=1, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_sig_capsules(self):
         sig = "Take 2 capsules of amoxicillin 500mg"
-        expected = StructuredSig(drug="amoxicillin", form="capsule", strength="500mg", frequencyType=None, interval=None, singleDosageAmount=2.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        expected = StructuredSig(drug="amoxicillin", form="capsule", strength="500mg", frequencyType=None, interval=1, times=None, singleDosageAmount=2.0, periodType=None, periodAmount=None, takeAsNeeded=False)
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_parse_multiple_instructions(self):
         sig = "take 1 tablet of atorvastatin every day and then 2 tablets every week"
         first_expected = StructuredSig(drug="atorvastatin", form="tablet", strength=None, frequencyType="Day",
-                                       interval=1, singleDosageAmount=1.0, periodType=None, periodAmount=None,
+                                       interval=1, singleDosageAmount=1.0, times=None, periodType=None, periodAmount=None,
                                        takeAsNeeded=False)
         second_expected = StructuredSig(drug="atorvastatin", form="tablet", strength=None, frequencyType="Week",
-                                        interval=1, singleDosageAmount=2.0, periodType=None, periodAmount=None,
+                                        interval=1, singleDosageAmount=2.0, times=None, periodType=None, periodAmount=None,
                                         takeAsNeeded=False)
         result = self.sig_parser.parse(sig)
         expected = [first_expected, second_expected]
@@ -100,9 +116,9 @@ class TestParseSigApi(unittest.TestCase):
     def test_parse_multiple_instructions2(self):
         sig = "take two tablets of benadryl every two days and then 1 tablet as needed"
         first_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType="Day", interval=2,
-                                       singleDosageAmount=2.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+                                       singleDosageAmount=2.0, periodType=None, times=None, periodAmount=None, takeAsNeeded=False)
         second_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType=None, interval=1,
-                                        singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=True)
+                                        singleDosageAmount=1.0, periodType=None, times=None, periodAmount=None, takeAsNeeded=True)
         result = self.sig_parser.parse(sig)
         expected = [first_expected, second_expected]
         self.assertEqual(result, expected)
@@ -110,25 +126,25 @@ class TestParseSigApi(unittest.TestCase):
     def test_parse_multiple_instructions3(self):
         sig = "take two tablets of benadryl every two days and then 1 tablet every week for 1 month and than 1 tablet every month"
         first_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType="Day", interval=2,
-                                       singleDosageAmount=2.0, periodType=None, periodAmount=None, takeAsNeeded=False)
-        second_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType='Week', interval=1,
+                                       singleDosageAmount=2.0, periodType=None, times=None, periodAmount=None, takeAsNeeded=False)
+        second_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, times=None, frequencyType='Week', interval=1,
                                         singleDosageAmount=1.0, periodType='Month', periodAmount=1, takeAsNeeded=False)
         third_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType='Month', interval=1,
-                                       singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+                                       singleDosageAmount=1.0, periodType=None, times=None, periodAmount=None, takeAsNeeded=False)
         result = self.sig_parser.parse(sig)
         expected = [first_expected, second_expected, third_expected]
         self.assertEqual(result, expected)
 
     def test_autocorrect_and__pre_process1(self):
         sig = "Tkae 1 tabet 3 tiems a day for 2 wekes"
-        expected = StructuredSig(drug=None, form="tablet", strength=None, frequencyType="Day", interval=3,
+        expected = StructuredSig(drug=None, form="tablet", strength=None, frequencyType="Day", interval=1, times=3,
                                  singleDosageAmount=1.0, periodType='Week', periodAmount=2, takeAsNeeded=False)
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_autocorrect_and__pre_process2(self):
         sig = "Tkae 1 talbet of ibuprofen 200mg 3 tiems every day for 10 wekes"
-        expected = StructuredSig(drug="ibuprofen", form="tablet", strength="200mg", frequencyType="Day", interval=3,
+        expected = StructuredSig(drug="ibuprofen", form="tablet", strength="200mg", frequencyType="Day", interval=1, times=3,
                                  singleDosageAmount=1.0, periodType="Week", periodAmount=10, takeAsNeeded=False)
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
@@ -142,14 +158,14 @@ class TestParseSigApi(unittest.TestCase):
     #
     def test_autocorrect_and__pre_process4(self):
         sig = "Atke 1 tab of Benadryl 3 tmies a day"
-        expected = StructuredSig(drug='benadryl', form='tablet', strength=None, frequencyType="Day", interval=3,
+        expected = StructuredSig(drug='benadryl', form='tablet', strength=None, frequencyType="Day", interval=1, times=3,
                                  singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
     def test_autocorrect_and_pre_process5(self):
         sig = "takr 1 tablet of Benadryl 3 times a dya"
-        expected = StructuredSig(drug='benadryl', form='tablet', strength=None, frequencyType="Day", interval=3,
+        expected = StructuredSig(drug='benadryl', form='tablet', strength=None, frequencyType="Day", interval=1, times=3,
                                  singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
@@ -164,11 +180,11 @@ class TestParseSigApi(unittest.TestCase):
 
     def test_autocorrect_and_pre_process7(self):
         sig = "tkae two talbets of benadryl every two days and then 1 talbet every week for 1 month and than 1 talbet every month"
-        first_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType="Day", interval=2,
+        first_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType="Day", interval=2, times=None,
                                        singleDosageAmount=2.0, periodType=None, periodAmount=None, takeAsNeeded=False)
-        second_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType='Week', interval=1,
+        second_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType='Week', interval=1, times=None,
                                         singleDosageAmount=1.0, periodType='Month', periodAmount=1, takeAsNeeded=False)
-        third_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType='Month', interval=1,
+        third_expected = StructuredSig(drug="benadryl", form="tablet", strength=None, frequencyType='Month', interval=1, times=None,
                                        singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
         result = self.sig_parser.parse(sig)
         expected = [first_expected, second_expected, third_expected]

--- a/tests/test_parsig_api.py
+++ b/tests/test_parsig_api.py
@@ -101,6 +101,13 @@ class TestParseSigApi(unittest.TestCase):
         result = self.sig_parser.parse(sig)[0]
         self.assertEqual(result, expected)
 
+    def test_parse_sig_capsules2(self):
+        sig = "Take 1 capsule by mouth twice daily (every 12 hours)"
+        expected = StructuredSig(drug=None, form="capsule", strength=None, frequencyType="Day", interval=1, times=2, singleDosageAmount=1.0, periodType=None, periodAmount=None, takeAsNeeded=False)
+        result = self.sig_parser.parse(sig)[0]
+        self.assertEqual(result, expected)
+
+
     def test_parse_multiple_instructions(self):
         sig = "take 1 tablet of atorvastatin every day and then 2 tablets every week"
         first_expected = StructuredSig(drug="atorvastatin", form="tablet", strength=None, frequencyType="Day",


### PR DESCRIPTION
Until this change, the field called `interval` contains the data of both "Take 1 tablet every X days" (the X value) AND,
"Take 1 tablet X times a day" the X value, which is associated with a newly introduced field called `times`. 

An instruction containing both "Take 1 tablet 3 times a day every 2 weeks" should not occur - but since this is free text the option is possible (though the `en_parsigs` model was not exposed to these examples so handles them not good)

The best way to understand thisis looking at the changes in tests.
This is a breaking change (`interval` field value can change for Sigs it is now represented as `times`) so a new version will be uploaded