### PR TITLE
Efficient processing of multiple dosage instructions using pipe

### DIFF
--- a/parsigs/parse_sig_api.py
+++ b/parsigs/parse_sig_api.py
@@ -92,14 +92,12 @@ The input string is pre processed, and than combining static rules and NER model
 
 
 def _parse_sigs(sig_lst, model: Language):
-    return _flatmap(lambda sig: _parse_sig(sig, model), sig_lst)
-
+    preprocessed_sigs = [_pre_process(sig) for sig in sig_lst]
+    model_outputs = [doc for doc in model.pipe(sig_preprocessed)]
+    return _flatmap(_create_structured_sigs, model_outputs)
 
 def _parse_sig(sig: str, model: Language):
-    sig_preprocessed = _pre_process(sig)
-    model_output = model(sig_preprocessed)
-
-    return _create_structured_sigs(model_output)
+    return _parse_sig([sig], model)
 
 
 def _autocorrect(sig):

--- a/parsigs/parse_sig_api.py
+++ b/parsigs/parse_sig_api.py
@@ -93,7 +93,7 @@ The input string is pre processed, and than combining static rules and NER model
 
 def _parse_sigs(sig_lst, model: Language):
     preprocessed_sigs = [_pre_process(sig) for sig in sig_lst]
-    model_outputs = [doc for doc in model.pipe(sig_preprocessed)]
+    model_outputs = [doc for doc in model.pipe(preprocessed_sigs)]
     return _flatmap(_create_structured_sigs, model_outputs)
 
 def _parse_sig(sig: str, model: Language):

--- a/parsigs/parse_sig_api.py
+++ b/parsigs/parse_sig_api.py
@@ -97,7 +97,7 @@ def _parse_sigs(sig_lst, model: Language):
     return _flatmap(_create_structured_sigs, model_outputs)
 
 def _parse_sig(sig: str, model: Language):
-    return _parse_sig([sig], model)
+    return _parse_sigs([sig], model)
 
 
 def _autocorrect(sig):


### PR DESCRIPTION
Currently we are processing sigs one by one serially in a single thread. We should be able to speed up the processing of multiple sigs in parallel using spacy's built in pipe() method.

Docs: https://spacy.io/api/language#pipe
More info: https://spacy.io/usage/processing-pipelines#multiprocessing